### PR TITLE
Fixed license version number.

### DIFF
--- a/src/SysPL.SyntaxTree/Associativity.cs
+++ b/src/SysPL.SyntaxTree/Associativity.cs
@@ -4,7 +4,7 @@
 //
 // SysPL is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // SysPL is distributed in the hope that it will be useful,

--- a/src/SysPL.SyntaxTree/BooleanLiteral.cs
+++ b/src/SysPL.SyntaxTree/BooleanLiteral.cs
@@ -4,7 +4,7 @@
 //
 // SysPL is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // SysPL is distributed in the hope that it will be useful,

--- a/src/SysPL.SyntaxTree/Function.cs
+++ b/src/SysPL.SyntaxTree/Function.cs
@@ -4,7 +4,7 @@
 //
 // SysPL is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // SysPL is distributed in the hope that it will be useful,

--- a/src/SysPL.SyntaxTree/FunctionDeclaration.cs
+++ b/src/SysPL.SyntaxTree/FunctionDeclaration.cs
@@ -4,7 +4,7 @@
 //
 // SysPL is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // SysPL is distributed in the hope that it will be useful,

--- a/src/SysPL.SyntaxTree/Identifier.cs
+++ b/src/SysPL.SyntaxTree/Identifier.cs
@@ -4,7 +4,7 @@
 //
 // SysPL is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // SysPL is distributed in the hope that it will be useful,

--- a/src/SysPL.SyntaxTree/InfixOperator.cs
+++ b/src/SysPL.SyntaxTree/InfixOperator.cs
@@ -4,7 +4,7 @@
 //
 // SysPL is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // SysPL is distributed in the hope that it will be useful,

--- a/src/SysPL.SyntaxTree/IntegerLiteral.cs
+++ b/src/SysPL.SyntaxTree/IntegerLiteral.cs
@@ -4,7 +4,7 @@
 //
 // SysPL is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // SysPL is distributed in the hope that it will be useful,

--- a/src/SysPL.SyntaxTree/Literal.cs
+++ b/src/SysPL.SyntaxTree/Literal.cs
@@ -4,7 +4,7 @@
 //
 // SysPL is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // SysPL is distributed in the hope that it will be useful,

--- a/src/SysPL.SyntaxTree/Operator.cs
+++ b/src/SysPL.SyntaxTree/Operator.cs
@@ -4,7 +4,7 @@
 //
 // SysPL is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // SysPL is distributed in the hope that it will be useful,

--- a/src/SysPL.SyntaxTree/PostfixOperator.cs
+++ b/src/SysPL.SyntaxTree/PostfixOperator.cs
@@ -4,7 +4,7 @@
 //
 // SysPL is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // SysPL is distributed in the hope that it will be useful,

--- a/src/SysPL.SyntaxTree/PrefixOperator.cs
+++ b/src/SysPL.SyntaxTree/PrefixOperator.cs
@@ -4,7 +4,7 @@
 //
 // SysPL is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // SysPL is distributed in the hope that it will be useful,

--- a/src/SysPL.SyntaxTree/StringLiteral.cs
+++ b/src/SysPL.SyntaxTree/StringLiteral.cs
@@ -4,7 +4,7 @@
 //
 // SysPL is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // SysPL is distributed in the hope that it will be useful,

--- a/src/SysPL.SyntaxTree/StructureDeclaration.cs
+++ b/src/SysPL.SyntaxTree/StructureDeclaration.cs
@@ -4,7 +4,7 @@
 //
 // SysPL is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // SysPL is distributed in the hope that it will be useful,

--- a/src/SysPL.SyntaxTree/VariableDeclaration.cs
+++ b/src/SysPL.SyntaxTree/VariableDeclaration.cs
@@ -4,7 +4,7 @@
 //
 // SysPL is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // SysPL is distributed in the hope that it will be useful,

--- a/src/SysPL.SyntaxTree/VariableDefinition.cs
+++ b/src/SysPL.SyntaxTree/VariableDefinition.cs
@@ -4,7 +4,7 @@
 //
 // SysPL is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // SysPL is distributed in the hope that it will be useful,


### PR DESCRIPTION
There is a bug in the extension that adds the license text. A PR (ymotongpoo/vsc-licenser#6) is created but so far no answer from the maintainer.